### PR TITLE
per-83-add-task-runner-course-aware-build-and-editor-configs-to

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,23 @@
+---
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 100
+BreakBeforeBraces: Allman
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+PointerAlignment: Right
+SpaceAfterCStyleCast: true
+IncludeBlocks: Preserve
+SortIncludes: false
+---
+Language: Cpp
+Standard: c++17
+---
+Language: Cpp
+# Plain C tweaks live in the C++ block since clang-format
+# uses the Cpp language for both C and C++.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# ---------- Stage 1/4: Base builder ----------
+# ---------- Stage 1/2: Base builder ----------
 FROM alpine:3.23.3 AS base-builder
 
 # OS packages
@@ -9,8 +9,12 @@ RUN apk update \
     coreutils=9.8-r1 \
     curl=8.17.0-r1
 
+# Taskfile
+# Pure-Go static binary
+RUN curl -sSL https://taskfile.dev/install.sh | sh -s -- -d -b /usr/local/bin
 
-# ---------- Stage 4/4: Runtime devcontainer ----------
+
+# ---------- Stage 2/2: Runtime devcontainer ----------
 FROM mcr.microsoft.com/devcontainers/base:ubuntu AS runtime
 
 # Binaries
@@ -27,16 +31,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-venv  \
     \
     # ---------- Shell Enhancements ----------
-    bash-completion=1:2.11-8 \
-    bat=0.24.0-1build1 \
-    ripgrep=14.1.0-1 \
+    bash-completion \
+    bat \
+    ripgrep \
+    \
+    # ---------- Haskell Development ----------
+    ghc \
+    cabal-install \
+    haskell-stack \
+    \
+    # ----------.github/workflows C/C++ Development ----------
+    gcc \
+    g++ \
+    gdb \
+    make \
+    cmake \
     \
     # ---------- Container & Network Tools ----------
-    bind9-dnsutils=1:9.18.39-0ubuntu0.24.04.2 \
+    bind9-dnsutils \
     && rm -rf /var/lib/apt/lists/*
 
 # PATH
 ENV PATH="${PATH}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # OSLO TZ
-ENV TZ="Europe/Helsibki"
+ENV TZ="Europe/Helsinki"

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{js,jsx,ts,tsx,json,jsonc,yml,yaml,md,html,css,scss}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD024": { "siblings_only": true },
+  "MD033": false,
+  "MD041": false
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,25 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "overrides": [
+    {
+      "files": ["*.md"],
+      "options": {
+        "proseWrap": "preserve"
+      }
+    },
+    {
+      "files": ["*.yml", "*.yaml"],
+      "options": {
+        "singleQuote": true
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -10,15 +10,17 @@ Preconfigured VS Code Devcontainer
 
 Includes:
 
-- Common tools
-- Formatters
+- Common tools (curl, ripgrep, bat, GitHub CLI)
+- Formatters & linters wired to VS Code (Prettier, Black, clang-format, shfmt, markdownlint)
+- [Task](https://taskfile.dev) — task runner with a course-aware C/C++ build target
 - Ubuntu 24 devcontainer
 
 Programming languages:
-- C++
-- Javascript/Typescript
+
+- C / C++ (gcc, g++, gdb, make, cmake)
+- Haskell (ghc, cabal, stack)
 - Python 3
-- R
+- JavaScript / TypeScript
 
 ## 📦 Requirements
 
@@ -47,3 +49,32 @@ Windows users should try [Github Desktop](https://desktop.github.com/download/)
 3. When prompted, select “Reopen in Container”.
 
 4. VS Code and Docker will handle the rest
+
+## ⚡ Building C / C++ with Task
+
+The repo ships a `Taskfile.yml`. The `build` target picks the compiler from the course in the path:
+
+| Course                 | Compiler | Standard   |
+| ---------------------- | -------- | ---------- |
+| cs.120                 | gcc      | `-std=c11` |
+| cs.110, cs.111, cs.115 | g++      | `-std=c++17` |
+
+```bash
+task --list                                                # show all tasks
+task build     -- src/courses/cs.120/unsigned_interval.c   # auto: gcc
+task build     -- src/courses/cs.110/.../foo.cpp           # auto: g++
+task build:c   -- path/to/file.c                           # force gcc
+task build:cpp -- path/to/file.cpp                         # force g++
+```
+
+The output binary is placed next to the source file with the extension stripped.
+
+## 📝 Editor configs
+
+Formatter and linter configs live at the repo root and are picked up automatically by VS Code:
+
+- `.editorconfig` — indent, EOL, trailing whitespace
+- `.clang-format` — C/C++ (LLVM base, Allman braces, 100 col)
+- `pyproject.toml` — Black + Ruff
+- `.prettierrc.json` — Prettier (JS/TS/JSON/MD/YAML)
+- `.markdownlint.json` — Markdown lint

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,66 @@
+version: '3'
+
+vars:
+  CFLAGS: '-Wall -Wextra -O2 -std=c11'
+  CXXFLAGS: '-Wall -Wextra -O2 -std=c++17'
+
+tasks:
+  default:
+    cmds:
+      - task --list
+
+  build:
+    desc: 'Build a C/C++ source file. Compiler chosen by course in the path (cs.120 → gcc, cs.110/111/115 → g++). Usage: task build -- <path/to/source>'
+    cmds:
+      - |
+        FILE="{{.CLI_ARGS}}"
+        if [ -z "$FILE" ]; then
+          echo "Usage: task build -- <path/to/source>"
+          exit 2
+        fi
+        if [ ! -f "$FILE" ]; then
+          echo "File not found: $FILE"
+          exit 1
+        fi
+        OUT="${FILE%.*}"
+        case "$FILE" in
+          *cs.110/*|*cs.111/*|*cs.115/*)
+            echo "==> g++ (course)"
+            g++ {{.CXXFLAGS}} -o "$OUT" "$FILE"
+            ;;
+          *cs.120/*)
+            echo "==> gcc (course)"
+            gcc {{.CFLAGS}} -o "$OUT" "$FILE"
+            ;;
+          *.cpp|*.cc|*.cxx|*.C)
+            echo "==> g++ (by extension)"
+            g++ {{.CXXFLAGS}} -o "$OUT" "$FILE"
+            ;;
+          *.c)
+            echo "==> gcc (by extension)"
+            gcc {{.CFLAGS}} -o "$OUT" "$FILE"
+            ;;
+          *)
+            echo "Cannot determine language for: $FILE"
+            exit 1
+            ;;
+        esac
+        echo "==> Built: $OUT"
+
+  build:c:
+    desc: 'Force gcc build. Usage: task build:c -- <file.c>'
+    cmds:
+      - |
+        FILE="{{.CLI_ARGS}}"
+        if [ -z "$FILE" ]; then echo "Usage: task build:c -- <file.c>"; exit 2; fi
+        gcc {{.CFLAGS}} -o "${FILE%.*}" "$FILE"
+        echo "==> Built: ${FILE%.*}"
+
+  build:cpp:
+    desc: 'Force g++ build. Usage: task build:cpp -- <file.cpp>'
+    cmds:
+      - |
+        FILE="{{.CLI_ARGS}}"
+        if [ -z "$FILE" ]; then echo "Usage: task build:cpp -- <file.cpp>"; exit 2; fi
+        g++ {{.CXXFLAGS}} -o "${FILE%.*}" "$FILE"
+        echo "==> Built: ${FILE%.*}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[tool.black]
+line-length = 100
+target-version = ["py311", "py312"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+extend-exclude = [
+  ".venv",
+  "build",
+  "dist",
+  "src/courses/**/student_template_project",
+]
+
+[tool.ruff.lint]
+select = [
+  "E",   # pycodestyle errors
+  "W",   # pycodestyle warnings
+  "F",   # pyflakes
+  "I",   # isort
+  "B",   # bugbear
+  "UP",  # pyupgrade
+  "SIM", # simplifications
+]
+ignore = [
+  "E501", # line length handled by formatter
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"


### PR DESCRIPTION
### Summary

- Install Task in the Alpine base-builder stage; runtime picks it up via the existing /usr/local/bin copy.
- Add haskell-stack alongside the existing ghc + cabal-install.
- Add Taskfile.yml with a build target that picks gcc (cs.120) vs g++ (cs.110/111/115) from the course in the path.
- Add repo-root editor configs: .editorconfig, .clang-format, pyproject.toml (Black + Ruff), .prettierrc.json, .markdownlint.json.
- README: document Task usage and the new editor configs.